### PR TITLE
Client-side label blacklist to block rendering of specific label names

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ parchment_version=1.20.1:2023.09.03
 loader_version=0.16.7
 
 # Mod Properties
-mod_version=2.6.4
+mod_version=2.7.0
 maven_group=red.jackf
 archives_base_name=whereisit
 

--- a/src/client/java/red/jackf/whereisit/client/WhereIsItConfigScreenBuilder.java
+++ b/src/client/java/red/jackf/whereisit/client/WhereIsItConfigScreenBuilder.java
@@ -40,6 +40,19 @@ public class WhereIsItConfigScreenBuilder {
                 .category(ConfigCategory.createBuilder()
                         .name(translatable("whereisit.config.title"))
                         .group(makeClientGroup(instance.defaults(), instance.instance()))
+                        .group(ListOption.<String>createBuilder()
+                                .name(translatable("whereisit.config.client.labelBlacklist"))
+                                .description(OptionDescription.of(
+                                        translatable("whereisit.config.client.labelBlacklist.description")
+                                ))
+                                .controller(StringControllerBuilder::create)
+                                .binding(
+                                        instance.defaults().getClient().labelBlacklist,
+                                        () -> instance.instance().getClient().labelBlacklist,
+                                        l -> instance.instance().getClient().labelBlacklist = l
+                                ).initial("")
+                                .insertEntriesAtEnd(true)
+                                .build())
                         .group(makeCommonGroup(instance.defaults(), instance.instance()))
                         .group(ListOption.<String>createBuilder()
                                 .name(translatable("whereisit.config.common.commandAliases"))

--- a/src/client/java/red/jackf/whereisit/client/render/Rendering.java
+++ b/src/client/java/red/jackf/whereisit/client/render/Rendering.java
@@ -150,6 +150,10 @@ public class Rendering {
     // schedule a label to be rendered; should be called before BEFORE_BLOCK_OUTLINE every frame
     public static void scheduleLabel(Vec3 pos, Component name, boolean seeThrough) {
         if (pos == null || name == null) return;
+
+        // check blacklist for label string
+        if (WhereIsItConfig.INSTANCE.instance().getClient().labelBlacklist.contains(name.getString())) return;
+
         scheduledLabels.add(new ScheduledLabel(pos, name, seeThrough));
     }
 

--- a/src/main/java/red/jackf/whereisit/config/WhereIsItConfig.java
+++ b/src/main/java/red/jackf/whereisit/config/WhereIsItConfig.java
@@ -80,6 +80,10 @@ public class WhereIsItConfig {
         @SerialEntry(comment = "Visual scale of the container names in the range [0.25, 2].")
         public float containerNameLabelScale = 1f;
 
+        @SerialEntry(comment = "A list of container names that will not display as floating labels. Disable by removing all options.")
+        public List<String> labelBlacklist = new ArrayList<>(labelBlacklistDefault);
+        private static final List<String> labelBlacklistDefault = List.of();
+
         @SerialEntry(comment = "Whether to use a random pride colour scheme each search.")
         public boolean randomScheme = true;
 

--- a/src/main/resources/assets/whereisit/lang/en_us.json
+++ b/src/main/resources/assets/whereisit/lang/en_us.json
@@ -21,6 +21,8 @@
   "whereisit.config.client.showContainerNamesInResults": "Show Container Names for Results",
   "whereisit.config.client.containerNameLabelScale": "Container Name Text Scale",
   "whereisit.config.client.containerNameLabelScale.slider": "Container Name Text Scale",
+  "whereisit.config.client.labelBlacklist": "Container label blacklist",
+  "whereisit.config.client.labelBlacklist.description": "A list of container names that will not display as floating labels. Disable by removing all options.",
   "whereisit.config.client.randomScheme": "Random Colour Scheme",
   "whereisit.config.client.randomScheme.description": "Whether to use a random pride colour scheme each search.",
   "whereisit.config.client.colourScheme": "Highlight Colour Scheme",


### PR DESCRIPTION
first time here, 👋

I was playing a gregtech modpack and some machines I placed down all had default names that would render as labels
I don't think I would ever name a container "modularUI" so a blacklist works for this usecase

I think I added everything in correctly, the config works as intended, and I also tested with the "Chest Tracker" mod to confirm it doesn't render blacklisted labels either